### PR TITLE
Redundant <application> tag

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,7 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.yarolegovich.lovelydialog">
-
-    <application android:theme="@style/AppTheme" />
-
-</manifest>
+    package="com.yarolegovich.lovelydialog"/>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -1,6 +1,4 @@
 <resources>
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar" />
-
     <style name="DialogButton">
         <item name="android:textAllCaps">true</item>
         <item name="android:clickable">true</item>


### PR DESCRIPTION
`<application>` tag in AndroidManifest.xml is redundant and (as a bonus) makes manifest merger fail if any `android:theme` is already specified.